### PR TITLE
Add license metadata to TypeScript package manifest

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@geoengine/openapi-client",
   "version": "0.0.33",
+    "license": "Apache-2.0",
   "description": "OpenAPI client for @geoengine/openapi-client",
   "author": "OpenAPI-Generator",
   "repository": {


### PR DESCRIPTION
Summary
Adds Apache-2.0 license metadata to typescript/package.json, matching the repository LICENSE file and making the published npm metadata clearer.

Verification
Checked npm metadata for @geoengine/openapi-client 0.0.33 has no license field.
Confirmed repository LICENSE is Apache License 2.0.
Parsed the edited typescript/package.json and verified license is Apache-2.0.

Tests not run; metadata-only change.