### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,18 @@
 {
-    "name": "@geoengine/openapi-client-dev",
-    "description": "Dev wrapper for @geoengine/openapi-client",
-    "private": true,
-    "workspaces": [
-      "typescript"
-    ],
-    "main": "./typescript/index.js",
-    "typings": "./typescript/dist/index.d.ts",
-    "module": "./typescript/dist/esm/index.js",
-    "scripts": {
-      "build": "npm run build --workspace=typescript",
-      "prepare": "npm run build --workspace=typescript"
-    }
+  "name": "@geoengine/openapi-client-dev",
+  "description": "Dev wrapper for @geoengine/openapi-client",
+  "private": true,
+  "workspaces": [
+    "typescript"
+  ],
+  "main": "./typescript/index.js",
+  "typings": "./typescript/dist/index.d.ts",
+  "module": "./typescript/dist/esm/index.js",
+  "scripts": {
+    "build": "npm run build --workspace=typescript",
+    "prepare": "npm run build --workspace=typescript"
+  },
+  "bugs": {
+    "url": "https://github.com/geo-engine/openapi-client/issues"
+  }
 }


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.